### PR TITLE
Add dataType to ajax request

### DIFF
--- a/src/mizar/js/JsonProvider.js
+++ b/src/mizar/js/JsonProvider.js
@@ -38,6 +38,7 @@ function handleJSONFeature( gwLayer, configuration )
 	$.ajax({
 		type: "GET",
 		url: configuration.url,
+		dataType: configuration.type,
 		success: function(response){
 			JsonProcessor.handleFeatureCollection( gwLayer, response );
 			gwLayer.addFeatureCollection( response );


### PR DESCRIPTION
Add dataType do ajax request of Json FeatureCollection. 
Without this getting json from this cross-domain example url won't work (https://raw.githubusercontent.com/jdomingu/ThreeGeoJSON/master/test_geojson/countries_states.geojson)